### PR TITLE
Update to work with Eclipse 4.5 (Mars)

### DIFF
--- a/org.eclipse.egit.bc.feature/feature.xml
+++ b/org.eclipse.egit.bc.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.egit.bc.feature"
       label="org.eclipse.egit.bc.feature"
-      version="1.0.0">
+      version="1.0.1">
 
    <description url="https://github.com/AlFranzis/EgitBeyondCompare">
       Eclipse EGit Beyond Compare integration
@@ -20,7 +20,7 @@
          id="org.eclipse.egit.bc"
          download-size="0"
          install-size="0"
-         version="1.0.0"
+         version="1.0.1"
          unpack="false"/>
 
 </feature>

--- a/org.eclipse.egit.bc.feature/pom.xml
+++ b/org.eclipse.egit.bc.feature/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>al.franzis.eclipse</groupId>
   <artifactId>org.eclipse.egit.bc.feature</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <packaging>eclipse-feature</packaging>
   <repositories>
     <!-- P2 repositories used by Tycho to resolve OSGi dependencies -->
@@ -41,7 +41,7 @@
     </plugins>
   </build>
   <properties> 
-    <tycho-version>0.18.0</tycho-version>
+    <tycho-version>0.18.1</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties> 
 </project>

--- a/org.eclipse.egit.bc.update/category.xml
+++ b/org.eclipse.egit.bc.update/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.eclipse.egit.bc.feature_1.0.0.jar" id="org.eclipse.egit.bc.feature" version="1.0.0">
+   <feature url="features/org.eclipse.egit.bc.feature_1.0.0.jar" id="org.eclipse.egit.bc.feature" version="1.0.1">
       <category name="EGitBeyondCompare"/>
    </feature>
    <category-def name="EGitBeyondCompare" label="EGitBeyondCompare"/>

--- a/org.eclipse.egit.bc.update/pom.xml
+++ b/org.eclipse.egit.bc.update/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>al.franzis.eclipse</groupId>
   <artifactId>org.eclipse.egit.bc.update</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <packaging>eclipse-repository</packaging>
   <repositories>
     <!-- P2 repositories used by Tycho to resolve OSGi dependencies -->
@@ -41,7 +41,7 @@
     </plugins>
   </build>
   <properties> 
-    <tycho-version>0.18.0</tycho-version>
+    <tycho-version>0.18.1</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties> 
   

--- a/org.eclipse.egit.bc/META-INF/MANIFEST.MF
+++ b/org.eclipse.egit.bc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.egit.bc
 Bundle-SymbolicName: org.eclipse.egit.bc;singleton:=true
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.1
 Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.egit.bc.Activator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",

--- a/org.eclipse.egit.bc/pom.xml
+++ b/org.eclipse.egit.bc/pom.xml
@@ -7,7 +7,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
   <groupId>al.franzis.eclipse</groupId>
   <artifactId>org.eclipse.egit.bc</artifactId>
   <packaging>eclipse-plugin</packaging>
-  <version>1.0.0</version> 
+  <version>1.0.1</version> 
   <repositories>
     <!-- P2 repositories used by Tycho to resolve OSGi dependencies -->
     <repository>
@@ -76,7 +76,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
   <dependencies>
   </dependencies>
   <properties> 
-    <tycho-version>0.18.0</tycho-version>
+    <tycho-version>0.18.1</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties> 
 </project>

--- a/org.eclipse.egit.bc/src/org/eclipse/egit/bc/BeyondCompareWithCommitActionHandler.java
+++ b/org.eclipse.egit.bc/src/org/eclipse/egit/bc/BeyondCompareWithCommitActionHandler.java
@@ -55,7 +55,7 @@ public class BeyondCompareWithCommitActionHandler extends BeyondCompareRepositor
 				Repository localRepo = mapping.getRepository();
 				RevWalk rw = new RevWalk(localRepo);
 				RevCommit commit = rw.parseCommit(commitId);
-				rw.release();
+				RevWalkUtil.close(rw);
 
 				String rightFilePath = BeyondCompareUtil.getCompareFilePath(repoRelativeBasePath, commit, localRepo);
 				String leftFilePath = baseFile.getLocation().toFile().getAbsolutePath();

--- a/org.eclipse.egit.bc/src/org/eclipse/egit/bc/BeyondCompareWithHeadActionHandler.java
+++ b/org.eclipse.egit.bc/src/org/eclipse/egit/bc/BeyondCompareWithHeadActionHandler.java
@@ -113,7 +113,7 @@ public class BeyondCompareWithHeadActionHandler extends BeyondCompareRepositoryA
 			if (latestFileCommit == null)
 				latestFileCommit = headCommit;
 		} finally {
-			rw.release();
+			RevWalkUtil.close(rw);
 		}
 
 		return latestFileCommit;

--- a/org.eclipse.egit.bc/src/org/eclipse/egit/bc/BeyondCompareWithRefActionHandler.java
+++ b/org.eclipse.egit.bc/src/org/eclipse/egit/bc/BeyondCompareWithRefActionHandler.java
@@ -56,7 +56,7 @@ public class BeyondCompareWithRefActionHandler extends BeyondCompareRepositoryAc
 					Repository localRepo = mapping.getRepository();
 					RevWalk rw = new RevWalk(localRepo);
 					RevCommit commit = rw.parseCommit(commitId);
-					rw.release();
+					RevWalkUtil.close(rw);
 
 					String rightFilePath = BeyondCompareUtil.getCompareFilePath(repoRelativeBasePath, commit, localRepo);
 					String leftFilePath = baseFile.getLocation().toFile().getAbsolutePath();

--- a/org.eclipse.egit.bc/src/org/eclipse/egit/bc/RevWalkUtil.java
+++ b/org.eclipse.egit.bc/src/org/eclipse/egit/bc/RevWalkUtil.java
@@ -1,0 +1,42 @@
+package org.eclipse.egit.bc;
+
+import java.lang.reflect.Method;
+
+import org.eclipse.jgit.revwalk.RevWalk;
+
+/**
+ * This class provides a utility method for closing/releasing instances
+ * of {@link RevWalk} that is independent of the name of the method.
+ * <p>
+ * The {@code release} method was renamed to {@code close} in the version
+ * of EGit that ships with Mars (Eclipse 4.5).
+ */
+public class RevWalkUtil {
+	private static Method closeMethod = null;
+	
+	// Query which version of RevWalk were using.  Determines 
+	// if we call close() or release().
+	static {
+		Method[] methods = RevWalk.class.getMethods();
+		for (Method method : methods) {
+			if ("close".equals(method.getName())) {
+				closeMethod = method;
+			} else if ("release".equals(method.getName())) {
+				closeMethod = method;
+			}
+		}
+	}
+	
+	public static void close(RevWalk rw) {
+		try {
+			closeMethod.invoke(rw, (Object[])null);
+		} catch (Exception e) {
+			// close/release doesn't throw a checked exception, so 
+			// just rethrow a RuntimeException
+			if (e instanceof RuntimeException) {
+				throw (RuntimeException)e;
+			}
+			throw new RuntimeException();
+		}
+	}
+}


### PR DESCRIPTION
In the version of eGit that ships with Mars, the method `org.eclipse.jgit.revwalk.RevWalk.release()` was renamed to close().  This pr updated the code to work with either version of RevWalk.
